### PR TITLE
Add Trueskill Evaluation for New AIs

### DIFF
--- a/experiments/new_league.py
+++ b/experiments/new_league.py
@@ -1,0 +1,424 @@
+# http://proceedings.mlr.press/v97/han19a/han19a.pdf
+
+import argparse
+import os
+import random
+import time
+from distutils.util import strtobool
+
+import numpy as np
+import pickle
+import pandas as pd
+import torch
+from gym_microrts.envs.vec_env import MicroRTSGridModeVecEnv, MicroRTSBotVecEnv
+from gym_microrts import microrts_ai # fmt: off
+from stable_baselines3.common.vec_env import VecMonitor, VecVideoRecorder
+from torch.utils.tensorboard import SummaryWriter
+from trueskill import TrueSkill, Rating, rate_1vs1, quality_1vs1
+from ppo_gridnet import Agent, MicroRTSStatsRecorder, CategoricalMasked
+import itertools
+from peewee import (
+    Model,
+    SqliteDatabase,
+    CharField,
+    ForeignKeyField,
+    TextField,
+    DateTimeField,
+    BooleanField,
+    FloatField,
+    SmallIntegerField,
+    JOIN,
+    fn,
+)
+import datetime
+from enum import Enum
+
+def parse_args():
+    # fmt: off
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--exp-name', type=str, default=os.path.basename(__file__).rstrip(".py"),
+        help='the name of this experiment')
+    parser.add_argument('--prod-mode', type=lambda x: bool(strtobool(x)), default=False, nargs='?', const=True,
+        help='run the script in production mode and use wandb to log outputs')
+    parser.add_argument('--wandb-project-name', type=str, default="cleanRL",
+        help="the wandb's project name")
+    parser.add_argument('--wandb-entity', type=str, default=None,
+        help="the entity (team) of wandb's project")
+
+    parser.add_argument('--partial-obs', type=lambda x: bool(strtobool(x)), default=False, nargs='?', const=True,
+        help='if toggled, the game will have partial observability')
+    parser.add_argument('--evals', nargs='+', default=['agent_sota.pt', "randomBiasedAI","workerRushAI","lightRushAI"], # ["coacAI"],
+        help='the ais')
+    parser.add_argument('--num-matches', type=int, default=10,
+        help='seed of the experiment')
+    # ["randomBiasedAI","workerRushAI","lightRushAI","coacAI"]
+    # default=["randomBiasedAI","workerRushAI","lightRushAI","coacAI","randomAI","passiveAI","naiveMCTSAI","mixedBot","rojo","izanagi","tiamat","droplet","guidedRojoA3N"]
+    args = parser.parse_args()
+    # fmt: on
+    return args
+
+
+db = SqliteDatabase('league.db')
+
+class BaseModel(Model):
+    class Meta:
+        database = db
+
+class AI(BaseModel):
+    name = CharField(unique=True)
+    mu = FloatField()
+    sigma = FloatField()
+    ai_type = CharField()
+
+class MatchHistory(BaseModel):
+    challenger = ForeignKeyField(AI, backref='challenger_match_histories')
+    defender = ForeignKeyField(AI, backref='defender_match_histories')
+    win = SmallIntegerField()
+    draw = SmallIntegerField()
+    loss = SmallIntegerField()
+    created_date = DateTimeField(default=datetime.datetime.now)
+
+db.connect()
+db.create_tables([AI, MatchHistory])
+
+
+class Outcome(Enum):
+    WIN = 1
+    DRAW = 0
+    LOSS = -1
+
+class Match:
+    def __init__(self, mode: int, partial_obs: bool, built_in_ais=None, built_in_ais2=None, rl_ai=None, rl_ai2=None):
+        # mode 0: rl-ai vs built-in-ai
+        # mode 1: rl-ai vs rl-ai
+        # mode 2: built-in-ai vs built-in-ai
+        self.mode = mode
+        self.partial_obs = partial_obs
+        self.built_in_ais = built_in_ais
+        self.built_in_ais2 = built_in_ais2
+        self.rl_ai = rl_ai
+        self.rl_ai2 = rl_ai2
+        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        max_steps = 5000
+        if mode == 0:
+            self.envs = MicroRTSGridModeVecEnv(
+                num_bot_envs=len(built_in_ais),
+                num_selfplay_envs=0,
+                partial_obs=partial_obs,
+                max_steps=max_steps,
+                render_theme=2,
+                ai2s=built_in_ais,
+                map_paths=["maps/16x16/basesWorkers16x16A.xml"],
+                reward_weight=np.array([10.0, 1.0, 1.0, 0.2, 1.0, 4.0]),
+            )
+            self.agent = Agent(self.envs).to(self.device)
+            self.agent.load_state_dict(torch.load(self.rl_ai))
+            self.agent.eval()
+        elif mode == 1:
+            self.envs = MicroRTSGridModeVecEnv(
+                num_bot_envs=0,
+                num_selfplay_envs=2,
+                partial_obs=partial_obs,
+                max_steps=max_steps,
+                render_theme=2,
+                map_paths=["maps/16x16/basesWorkers16x16A.xml"],
+                reward_weight=np.array([10.0, 1.0, 1.0, 0.2, 1.0, 4.0]),
+            )
+            self.agent = Agent(self.envs).to(self.device)
+            self.agent.load_state_dict(torch.load(self.rl_ai))
+            self.agent.eval()
+            self.agent2 = Agent(self.envs).to(self.device)
+            self.agent2.load_state_dict(torch.load(self.rl_ai2))
+            self.agent2.eval()
+        else:
+            self.envs = MicroRTSBotVecEnv(
+                ai1s=built_in_ais,
+                ai2s=built_in_ais2,
+                max_steps=max_steps,
+                render_theme=2,
+                map_paths=["maps/16x16/basesWorkers16x16.xml"],
+                reward_weight=np.array([10.0, 1.0, 1.0, 0.2, 1.0, 4.0])
+            )
+        self.envs = MicroRTSStatsRecorder(self.envs)
+        self.envs = VecMonitor(self.envs)
+
+    def run(self, num_matches=7):
+        if self.mode == 0:
+            return self.run_m0(num_matches)
+        elif self.mode == 1:
+            return self.run_m1(num_matches)
+        else:
+            return self.run_m2(num_matches)
+        
+    def run_m0(self, num_matches):
+        results = []
+        mapsize = 16 * 16
+        next_obs = torch.Tensor(self.envs.reset()).to(self.device)
+        while True:
+            # self.envs.render()
+            # ALGO LOGIC: put action logic here
+            with torch.no_grad():
+                mask = torch.tensor(np.array(self.envs.get_action_mask())).to(self.device)
+                action, _, _, _, _ = self.agent.get_action_and_value(
+                    next_obs, envs=self.envs, invalid_action_masks=mask, device=self.device
+                )
+            try:
+                next_obs, rs, ds, infos = self.envs.step(action.cpu().numpy().reshape(self.envs.num_envs, -1))
+                next_obs = torch.Tensor(next_obs).to(self.device)
+            except Exception as e:
+                e.printStackTrace()
+                raise
+    
+            for idx, info in enumerate(infos):
+                if "episode" in info.keys():
+                    results += [info["microrts_stats"]["WinLossRewardFunction"]]
+                    print("against", info["microrts_stats"]["WinLossRewardFunction"])
+                    if len(results) >= num_matches:
+                        return results
+
+    def run_m1(self, num_matches):
+        results = []
+        mapsize = 16 * 16
+        next_obs = torch.Tensor(self.envs.reset()).to(self.device)
+        while True:
+            # self.envs.render()
+            # ALGO LOGIC: put action logic here
+            with torch.no_grad():
+                mask = torch.tensor(np.array(self.envs.get_action_mask())).to(self.device)
+                
+                p1_obs = next_obs[::2]
+                p2_obs = next_obs[1::2]
+                p1_mask = mask[::2]
+                p2_mask = mask[1::2]
+                
+                p1_action, _, _, _, _ = self.agent.get_action_and_value(
+                    p1_obs, envs=self.envs, invalid_action_masks=p1_mask, device=self.device
+                )
+                p2_action, _, _, _, _ = self.agent2.get_action_and_value(
+                    p2_obs, envs=self.envs, invalid_action_masks=p2_mask, device=self.device
+                )
+                action = torch.zeros((self.envs.num_envs, p2_action.shape[1], p2_action.shape[2]))
+                action[::2] = p1_action
+                action[1::2] = p2_action
+
+            try:
+                next_obs, rs, ds, infos = self.envs.step(action.cpu().numpy().reshape(self.envs.num_envs, -1))
+                next_obs = torch.Tensor(next_obs).to(self.device)
+            except Exception as e:
+                e.printStackTrace()
+                raise
+    
+            for idx, info in enumerate(infos):
+                if "episode" in info.keys():
+                    results += [info["microrts_stats"]["WinLossRewardFunction"]]
+                    print(idx, info["microrts_stats"]["WinLossRewardFunction"])
+                    if len(results) >= num_matches:
+                        return results
+
+    def run_m2(self, num_matches):
+        results = []
+        self.envs.reset()
+        while True:
+            # self.envs.render()
+            # dummy actions
+            next_obs, reward, done, infos = self.envs.step(
+                [[[0, 0, 0, 0, 0, 0, 0, 0],
+                  [0, 0, 0, 0, 0, 0, 0, 0],]]) 
+            for idx, info in enumerate(infos):
+                if "episode" in info.keys():
+                    results += [info["microrts_stats"]["WinLossRewardFunction"]]
+                    print(idx, info["microrts_stats"]["WinLossRewardFunction"])
+                    if len(results) >= num_matches:
+                        return results
+
+def get_ai_type(ai_name):
+    if ai_name[-3:] == ".pt":
+        return 'rl_ai'
+    else:
+        return 'built_in_ai'
+
+
+def get_match_history(ai_name):
+    query = (MatchHistory
+        .select(
+            AI.name,
+            fn.SUM(MatchHistory.win).alias('wins'),
+            fn.SUM(MatchHistory.draw).alias('draws'),
+            fn.SUM(MatchHistory.loss).alias('losss'),
+        )
+        .join(AI, JOIN.LEFT_OUTER, on=MatchHistory.defender)
+        .group_by(MatchHistory.defender)
+        .where(MatchHistory.challenger == AI.get(name=ai_name))
+    )
+    return pd.DataFrame(list(query.dicts()))
+
+def get_leaderboard():
+    query = (AI.select(
+            AI.name,
+            AI.mu,
+            AI.sigma,
+            (AI.mu - 3 * AI.sigma).alias('trueskill'),
+        )
+        .order_by((AI.mu - 3 * AI.sigma).desc())
+    )
+    return pd.DataFrame(list(query.dicts()))
+
+if __name__ == "__main__":
+    args = parse_args()
+    existing_ai_names = [item.name for item in AI.select()]
+    all_ai_names = existing_ai_names + args.evals
+
+    for ai_name in all_ai_names:  
+        ai = AI.get_or_none(name=ai_name)
+        if ai is None:
+            ai = AI(
+                name=ai_name, 
+                mu=25.0,
+                sigma=8.333333333333334,
+                ai_type=get_ai_type(ai_name))
+            ai.save()
+
+    # case 1: initialize the league with round robin
+    if len(existing_ai_names) == 0:
+        match_ups = list(itertools.combinations(all_ai_names, 2))
+        np.random.shuffle(match_ups)
+        for idx in range(2): # switch player 1 and 2's starting locations
+            for match_up in match_ups:
+                if idx == 0:
+                    match_up = list(reversed(match_up))
+                rl_ais = []
+                built_in_ais = []
+                for ai in match_up:
+                    if ai[-3:] == ".pt":
+                        rl_ais += [ai]
+                    else:
+                        built_in_ais += [ai]
+                
+                if len(rl_ais) == 1:
+                    print("mode0")
+                    p0 = rl_ais[0]
+                    p1 = built_in_ais[0]
+                    m = Match(0, False, rl_ai=p0, built_in_ais=[eval(f"microrts_ai.{p1}")])
+                elif len(rl_ais) == 2:
+                    print("mode1")
+                    p0 = rl_ais[0]
+                    p1 = rl_ais[1]
+                    m = Match(1, False, rl_ai=p0, rl_ai2=p1)
+                else:
+                    print("mode2")
+                    p0 = built_in_ais[0]
+                    p1 = built_in_ais[1]
+                    m = Match(2, False, built_in_ais=[eval(f"microrts_ai.{p0}")], built_in_ais2=[eval(f"microrts_ai.{p1}")])
+                
+                challenger = AI.get_or_none(name=p0)
+                defender = AI.get_or_none(name=p1)
+                
+                r = m.run(args.num_matches // 2)
+                for item in r:
+                    drawn = False
+                    if item == Outcome.WIN.value:
+                        winner = challenger
+                        loser = defender
+                    elif item == Outcome.DRAW.value:
+                        drawn = True
+                    else:
+                        winner = defender
+                        loser = challenger
+                    
+                    winner_rating, loser_rating = rate_1vs1(
+                        Rating(winner.mu, winner.sigma),
+                        Rating(loser.mu, loser.sigma),
+                        drawn=drawn)
+
+                    winner.mu, winner.sigma = winner_rating.mu, winner_rating.sigma
+                    loser.mu, loser.sigma = loser_rating.mu, loser_rating.sigma
+                    winner.save()
+                    loser.save()
+                    
+                    MatchHistory(
+                        challenger=challenger,
+                        defender=defender,
+                        win=int(item == 1),
+                        draw=int(item == 0),
+                        loss=int(item == -1),
+                    ).save()
+
+        query = (AI.select(
+                AI.name,
+                AI.mu,
+                AI.sigma,
+                (AI.mu - 3 * AI.sigma).alias('trueskill'),
+            )
+            .order_by((AI.mu - 3 * AI.sigma).desc())
+        )
+            # )
+        # (AI.get(name='agent_sota.pt')
+        #     .challenger_match_histories
+        #     .select(Count)
+
+                    # if item == Outcome.WIN:
+                    #     rate_1vs1(
+                    #         Rating(challenger.mu, challenger.sigma),
+                    #         Rating(defender.mu, defender.sigma))
+                        
+                        
+                    #     ratings[p0], ratings[p1] = rate_1vs1(ratings[p0], ratings[p1])
+                    #     if p1 not in match_historys[p0]:
+                    #         match_historys[p0][p1] = [1, 0, 0]
+                    #     else:
+                    #         match_historys[p0][p1][0] += 1
+                    #     if p0 not in match_historys[p1]:
+                    #         match_historys[p1][p0] = [0, 0, 1]
+                    #     else:
+                    #         match_historys[p1][p0][2] += 1
+                    # elif item == 0:
+                    #     ratings[p0], ratings[p1] = rate_1vs1(ratings[p0], ratings[p1], drawn=True)
+                    #     if p1 not in match_historys[p0]:
+                    #         match_historys[p0][p1] = [0, 1, 0]
+                    #     else:
+                    #         match_historys[p0][p1][1] += 1
+                    #     if p0 not in match_historys[p1]:
+                    #         match_historys[p1][p0] = [0, 1, 0]
+                    #     else:
+                    #         match_historys[p1][p0][1] += 1
+                    # else:
+                    #     ratings[p1], ratings[p0] = rate_1vs1(ratings[p1], ratings[p0])
+                    #     if p1 not in match_historys[p0]:
+                    #         match_historys[p0][p1] = [0, 0, 1]
+                    #     else:
+                    #         match_historys[p0][p1][2] += 1
+                    #     if p0 not in match_historys[p1]:
+                    #         match_historys[p1][p0] = [1, 0, 0]
+                    #     else:
+                    #         match_historys[p1][p0][0] += 1
+        # leaderboard = sorted(ratings, key=lambda item: ratings[item].mu - 3 *ratings[item].sigma, reverse=True)
+        # leaderboard = [(item, round(ratings[item].mu - 3 *ratings[item].sigma,2), ratings[item])  for item in leaderboard]
+        
+        # trueskills = pd.DataFrame(data = [[item[0], item[1], item[2].mu, item[2].sigma] for item in leaderboard], columns=["ai", "trueskill", "mu", "sigma"])
+        
+        # match_historys_dfs = [[key, pd.DataFrame(match_historys[key], index=["win", "tie", "loss"]).T] for key in match_historys]
+        # dataset = [trueskills, match_historys_dfs]
+        # with open('dataset.pickle', 'wb') as handle:
+        #     pickle.dump(dataset, handle, protocol=pickle.HIGHEST_PROTOCOL)
+        
+        
+        # if args.prod_mode:
+        #     import wandb
+
+        #     experiment_name = f"{args.exp_name}__{int(time.time())}"
+        #     run = wandb.init(
+        #         project=args.wandb_project_name,
+        #         entity=args.wandb_entity,
+        #         sync_tensorboard=True,
+        #         config=vars(args),
+        #         name=experiment_name,
+        #         monitor_gym=True,
+        #         save_code=True,
+        #     )
+        #     wandb.save('dataset.pickle')
+        #     wandb.log({"trueskills": wandb.Table(dataframe=trueskills)})
+        #     artifact = wandb.Artifact("trueskills", type="dataset")
+        #     artifact.add(wandb.Table(dataframe=trueskills), "trueskills")
+        #     run.log_artifact(artifact)
+        #     for item in match_historys_dfs:
+        #         wandb.log({item[0].rstrip(".pt"): wandb.Table(dataframe=item[1].reset_index(level=0))})

--- a/experiments/new_league.py
+++ b/experiments/new_league.py
@@ -418,8 +418,9 @@ if __name__ == "__main__":
         for new_ai_name in new_ai_names:
             ai = AI.get(name=new_ai_name)
             binary_search(leaderboard, 0, len(leaderboard), ai.name, n=5)
-            
-
+    
+    print("=======================")
+    print(get_leaderboard())
 
         # if args.prod_mode:
         #     import wandb

--- a/experiments/new_league.py
+++ b/experiments/new_league.py
@@ -172,7 +172,6 @@ class Match:
             for idx, info in enumerate(infos):
                 if "episode" in info.keys():
                     results += [info["microrts_stats"]["WinLossRewardFunction"]]
-                    print("against", info["microrts_stats"]["WinLossRewardFunction"])
                     if len(results) >= num_matches:
                         return results
 
@@ -211,7 +210,6 @@ class Match:
             for idx, info in enumerate(infos):
                 if "episode" in info.keys():
                     results += [info["microrts_stats"]["WinLossRewardFunction"]]
-                    print(idx, info["microrts_stats"]["WinLossRewardFunction"])
                     if len(results) >= num_matches:
                         return results
 
@@ -227,7 +225,6 @@ class Match:
             for idx, info in enumerate(infos):
                 if "episode" in info.keys():
                     results += [info["microrts_stats"]["WinLossRewardFunction"]]
-                    print(idx, info["microrts_stats"]["WinLossRewardFunction"])
                     if len(results) >= num_matches:
                         return results
 
@@ -295,17 +292,14 @@ if __name__ == "__main__":
                         built_in_ais += [ai]
                 
                 if len(rl_ais) == 1:
-                    print("mode0")
                     p0 = rl_ais[0]
                     p1 = built_in_ais[0]
                     m = Match(0, False, rl_ai=p0, built_in_ais=[eval(f"microrts_ai.{p1}")])
                 elif len(rl_ais) == 2:
-                    print("mode1")
                     p0 = rl_ais[0]
                     p1 = rl_ais[1]
                     m = Match(1, False, rl_ai=p0, rl_ai2=p1)
                 else:
-                    print("mode2")
                     p0 = built_in_ais[0]
                     p1 = built_in_ais[1]
                     m = Match(2, False, built_in_ais=[eval(f"microrts_ai.{p0}")], built_in_ais2=[eval(f"microrts_ai.{p1}")])
@@ -324,6 +318,8 @@ if __name__ == "__main__":
                     else:
                         winner = defender
                         loser = challenger
+                        
+                    print(f"{winner.name} {'draws' if drawn else 'wins'} {loser.name}")
                     
                     winner_rating, loser_rating = rate_1vs1(
                         Rating(winner.mu, winner.sigma),
@@ -343,65 +339,6 @@ if __name__ == "__main__":
                         loss=int(item == -1),
                     ).save()
 
-        query = (AI.select(
-                AI.name,
-                AI.mu,
-                AI.sigma,
-                (AI.mu - 3 * AI.sigma).alias('trueskill'),
-            )
-            .order_by((AI.mu - 3 * AI.sigma).desc())
-        )
-            # )
-        # (AI.get(name='agent_sota.pt')
-        #     .challenger_match_histories
-        #     .select(Count)
-
-                    # if item == Outcome.WIN:
-                    #     rate_1vs1(
-                    #         Rating(challenger.mu, challenger.sigma),
-                    #         Rating(defender.mu, defender.sigma))
-                        
-                        
-                    #     ratings[p0], ratings[p1] = rate_1vs1(ratings[p0], ratings[p1])
-                    #     if p1 not in match_historys[p0]:
-                    #         match_historys[p0][p1] = [1, 0, 0]
-                    #     else:
-                    #         match_historys[p0][p1][0] += 1
-                    #     if p0 not in match_historys[p1]:
-                    #         match_historys[p1][p0] = [0, 0, 1]
-                    #     else:
-                    #         match_historys[p1][p0][2] += 1
-                    # elif item == 0:
-                    #     ratings[p0], ratings[p1] = rate_1vs1(ratings[p0], ratings[p1], drawn=True)
-                    #     if p1 not in match_historys[p0]:
-                    #         match_historys[p0][p1] = [0, 1, 0]
-                    #     else:
-                    #         match_historys[p0][p1][1] += 1
-                    #     if p0 not in match_historys[p1]:
-                    #         match_historys[p1][p0] = [0, 1, 0]
-                    #     else:
-                    #         match_historys[p1][p0][1] += 1
-                    # else:
-                    #     ratings[p1], ratings[p0] = rate_1vs1(ratings[p1], ratings[p0])
-                    #     if p1 not in match_historys[p0]:
-                    #         match_historys[p0][p1] = [0, 0, 1]
-                    #     else:
-                    #         match_historys[p0][p1][2] += 1
-                    #     if p0 not in match_historys[p1]:
-                    #         match_historys[p1][p0] = [1, 0, 0]
-                    #     else:
-                    #         match_historys[p1][p0][0] += 1
-        # leaderboard = sorted(ratings, key=lambda item: ratings[item].mu - 3 *ratings[item].sigma, reverse=True)
-        # leaderboard = [(item, round(ratings[item].mu - 3 *ratings[item].sigma,2), ratings[item])  for item in leaderboard]
-        
-        # trueskills = pd.DataFrame(data = [[item[0], item[1], item[2].mu, item[2].sigma] for item in leaderboard], columns=["ai", "trueskill", "mu", "sigma"])
-        
-        # match_historys_dfs = [[key, pd.DataFrame(match_historys[key], index=["win", "tie", "loss"]).T] for key in match_historys]
-        # dataset = [trueskills, match_historys_dfs]
-        # with open('dataset.pickle', 'wb') as handle:
-        #     pickle.dump(dataset, handle, protocol=pickle.HIGHEST_PROTOCOL)
-        
-        
         # if args.prod_mode:
         #     import wandb
 

--- a/experiments/new_league.py
+++ b/experiments/new_league.py
@@ -95,8 +95,7 @@ class Match:
         # mode 0: rl-ai vs built-in-ai
         # mode 1: rl-ai vs rl-ai
         # mode 2: built-in-ai vs built-in-ai
-        
-        
+
         built_in_ais=None
         built_in_ais2=None
         rl_ai=None
@@ -372,6 +371,7 @@ if __name__ == "__main__":
             
             if high >= low:
                 mid = (high + low) // 2
+                print(f"high {high}, low {low}, len(leaderboard) {len(leaderboard)}, mid {mid}")
                 match_up = (ai, leaderboard.iloc[mid]["name"])
                 winner = AI.get(name=ai) # dummy setting
                 if ai != leaderboard.iloc[mid]["name"]:

--- a/experiments/ppo_gridnet.py
+++ b/experiments/ppo_gridnet.py
@@ -468,14 +468,13 @@ if __name__ == "__main__":
                 wandb.save(f"models/{experiment_name}/agent.pt", base_path=f"models/{experiment_name}", policy="now")
                 subprocess.Popen(["python", "new_league.py", "--evals", f"models/{experiment_name}/{global_step}.pt"])
                 eval_queue += [f"models/{experiment_name}/{global_step}.pt"]
-                print("called")
+                print(f"Evaluating models/{experiment_name}/{global_step}.pt")
 
             ## EVALUATION LOGIC:
             if os.path.exists("league.csv"):
                 league = pd.read_csv("league.csv", index_col="name")
                 if len(eval_queue) > 0:
                     model_path = eval_queue[0]
-                    print(f"Evaluating {model_path}")
                     if model_path in league.index:
                         model_global_step = int(model_path.split("/")[-1][:-3])
                         print(f"Model global step: {model_global_step}")

--- a/experiments/ppo_gridnet.py
+++ b/experiments/ppo_gridnet.py
@@ -4,9 +4,11 @@ import argparse
 import os
 import random
 import time
+import subprocess
 from distutils.util import strtobool
 
 import numpy as np
+import pandas as pd
 import torch
 import torch.nn as nn
 import torch.optim as optim
@@ -39,7 +41,7 @@ def parse_args():
         help='run the script in production mode and use wandb to log outputs')
     parser.add_argument('--capture-video', type=lambda x: bool(strtobool(x)), default=False, nargs='?', const=True,
         help='weather to capture videos of the agent performances (check out `videos` folder)')
-    parser.add_argument('--wandb-project-name', type=str, default="cleanRL",
+    parser.add_argument('--wandb-project-name', type=str, default="gym-microrts",
         help="the wandb's project name")
     parser.add_argument('--wandb-entity', type=str, default=None,
         help="the entity (team) of wandb's project")
@@ -83,6 +85,8 @@ def parse_args():
         help="Toggle learning rate annealing for policy and value networks")
     parser.add_argument('--clip-vloss', type=lambda x: bool(strtobool(x)), default=True, nargs='?', const=True,
         help='Toggles wheter or not to use a clipped loss for the value function, as per the paper.')
+    parser.add_argument('--num-models', type=int, default=100,
+        help='the number of models saved')
 
     args = parser.parse_args()
     if not args.seed:
@@ -90,6 +94,8 @@ def parse_args():
     args.num_envs = args.num_selfplay_envs + args.num_bot_envs
     args.batch_size = int(args.num_envs * args.num_steps)
     args.minibatch_size = int(args.batch_size // args.n_minibatch)
+    args.num_updates = args.total_timesteps // args.batch_size
+    args.save_frequency = int(args.num_updates // 100)
     # fmt: on
     return args
 
@@ -307,7 +313,6 @@ if __name__ == "__main__":
     # https://github.com/ikostrikov/pytorch-a2c-ppo-acktr-gail/blob/84a7582477fb0d5c82ad6d850fe476829dddd2e1/a2c_ppo_acktr/storage.py#L60
     next_obs = torch.Tensor(envs.reset()).to(device)
     next_done = torch.zeros(args.num_envs).to(device)
-    num_updates = args.total_timesteps // args.batch_size
 
     ## CRASH AND RESUME LOGIC:
     starting_update = 1
@@ -329,11 +334,12 @@ if __name__ == "__main__":
         print(param_tensor, "\t", agent.state_dict()[param_tensor].size())
     total_params = sum([param.nelement() for param in agent.parameters()])
     print("Model's total parameters:", total_params)
+    eval_queue = []
 
-    for update in range(starting_update, num_updates + 1):
+    for update in range(starting_update, args.num_updates + 1):
         # Annealing the rate if instructed to do so.
         if args.anneal_lr:
-            frac = 1.0 - (update - 1.0) / num_updates
+            frac = 1.0 - (update - 1.0) / args.num_updates
             lrnow = lr(frac)
             optimizer.param_groups[0]["lr"] = lrnow
 
@@ -454,11 +460,28 @@ if __name__ == "__main__":
 
         ## CRASH AND RESUME LOGIC:
         if args.prod_mode:
-            # make sure to tune `CHECKPOINT_FREQUENCY` so models are not saved too frequently
-            if update % CHECKPOINT_FREQUENCY == 0:
-                torch.save(agent.state_dict(), f"{wandb.run.dir}/agent.pt")
-                wandb.save(f"{wandb.run.dir}/agent.pt", policy="now")
-                print("model saved")
+            if (update-1) % args.save_frequency == 0:
+                if not os.path.exists(f"models/{experiment_name}"):
+                    os.makedirs(f"models/{experiment_name}")
+                torch.save(agent.state_dict(), f"models/{experiment_name}/agent.pt")
+                torch.save(agent.state_dict(), f"models/{experiment_name}/{global_step}.pt")
+                wandb.save(f"models/{experiment_name}/agent.pt", base_path=f"models/{experiment_name}", policy="now")
+                subprocess.Popen(["python", "new_league.py", "--evals", f"models/{experiment_name}/{global_step}.pt"])
+                eval_queue += [f"models/{experiment_name}/{global_step}.pt"]
+                print("called")
+
+            ## EVALUATION LOGIC:
+            if os.path.exists("league.csv"):
+                league = pd.read_csv("league.csv", index_col="name")
+                if len(eval_queue) > 0:
+                    model_path = eval_queue[0]
+                    print(f"Evaluating {model_path}")
+                    if model_path in league.index:
+                        model_global_step = int(model_path.split("/")[-1][:-3])
+                        print(f"Model global step: {model_global_step}")
+                        eval_queue = eval_queue[1:]
+                        print("charts/trueskill", league.loc[model_path]["trueskill"], model_global_step)
+                        writer.add_scalar("charts/trueskill", league.loc[model_path]["trueskill"], model_global_step)
 
         # TRY NOT TO MODIFY: record rewards for plotting purposes
         writer.add_scalar("charts/learning_rate", optimizer.param_groups[0]["lr"], global_step)

--- a/poetry.lock
+++ b/poetry.lock
@@ -1063,6 +1063,14 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "peewee"
+version = "3.14.8"
+description = "a little orm"
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "pexpect"
 version = "4.8.0"
 description = "Pexpect allows easy control of interactive console applications."
@@ -4030,7 +4038,7 @@ spyder = ["spyder"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "7d777d1db1b729c3e44e7a16d7b0edec25f7580310c34639931a2790d4cf6799"
+content-hash = "2e704b53d7a7b99ff454de18c6f307ff8b5930231f3b022d7caabb0a956a37cd"
 
 [metadata.files]
 absl-py = [
@@ -4679,6 +4687,9 @@ pathspec = [
 ]
 pathtools = [
     {file = "pathtools-0.1.2.tar.gz", hash = "sha256:7c35c5421a39bb82e58018febd90e3b6e5db34c5443aaaf742b3f33d4655f1c0"},
+]
+peewee = [
+    {file = "peewee-3.14.8.tar.gz", hash = "sha256:01bd7f734defb08d7a3346a0c0ca7011bc8d0d685934ec0e001b3371d522ec53"},
 ]
 pexpect = [
     {file = "pexpect-4.8.0-py2.py3-none-any.whl", hash = "sha256:0b48a55dcb3c05f3329815901ea4fc1537514d6ba867a152b581d69ae3710937"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ python = "^3.7"
 gym = "^0.18.3"
 JPype1 = "^1.3.0"
 spyder = {version = "^5.1.5", optional = true}
+peewee = "^3.14.8"
 
 [tool.poetry.dev-dependencies]
 poetry-dynamic-versioning = "^0.13.0"


### PR DESCRIPTION
This PR allows the users to evaluate on newer AIs.

## Bootstrap trueskills for the initial league
```bash
poetry install
cd experiments
poetry run python new_league.py --evals agent_sota.pt randomBiasedAI workerRushAI lightRushAI
```

```
=======================
             name         mu     sigma  trueskill
0   agent_sota.pt  39.300444  2.273100  32.481145
1    workerRushAI  31.810887  2.335282  24.805039
2     lightRushAI  25.776148  2.388974  18.609226
3  randomBiasedAI  11.527615  3.700987   0.424655
```


## Add trueskills evals for additional agents
```bash

poetry run python new_league.py --evals coacAI
```

```
             name         mu     sigma  trueskill
0   agent_sota.pt  39.300444  2.273100  32.481145
1          coacAI  36.132655  1.769652  30.823699
2    workerRushAI  31.810887  2.335282  24.805039
3     lightRushAI  25.776148  2.388974  18.609226
4  randomBiasedAI  11.527615  3.700987   0.424655
```


Notice how the initial league's (i.e. reference agents) trueskill rating is always fixed, which corresponds to OpenAI Five and Alphastar's methods.


## Evaluate Trueskill during training
Finally, there is support for evaluating Trueskill during training. This is achieved by using `subprocess` to call the league evaluation.

```bash
cd experiments
rm -rf dataset.db
rm -rf dataset.csv
poetry run python new_league.py --evals randomBiasedAI workerRushAI lightRushAI coacAI
poetry run python ppo_gridnet.py --prod-mode
``` 

