### PR TITLE
Fix wandb tensorboard bug of not logging metrics

### DIFF
--- a/experiments/ppo_gridnet.py
+++ b/experiments/ppo_gridnet.py
@@ -251,12 +251,13 @@ if __name__ == "__main__":
         run = wandb.init(
             project=args.wandb_project_name,
             entity=args.wandb_entity,
-            sync_tensorboard=True,
+            # sync_tensorboard=True,
             config=vars(args),
             name=experiment_name,
             monitor_gym=True,
             save_code=True,
         )
+        wandb.tensorboard.patch(save=False)
         CHECKPOINT_FREQUENCY = 50
     writer = SummaryWriter(f"runs/{experiment_name}")
     writer.add_text(


### PR DESCRIPTION
On windows, the wandb's tensorboard integration could break, not logging anything as shown below:

![image](https://user-images.githubusercontent.com/5555347/140950136-6c134a21-05ff-4d6c-99f8-48b28cc4d84e.png)

This can be fixed by 

```python
        run = wandb.init(
            project=args.wandb_project_name,
            entity=args.wandb_entity,
            sync_tensorboard=True,
            config=vars(args),
            name=experiment_name,
            monitor_gym=True,
            save_code=True,
        )
```
to 

```python
        run = wandb.init(
            project=args.wandb_project_name,
            entity=args.wandb_entity,
            # sync_tensorboard=True,
            config=vars(args),
            name=experiment_name,
            monitor_gym=True,
            save_code=True,
        )
        wandb.tensorboard.patch(save=False)
```

So basically comment out `# sync_tensorboard=True,` and add `wandb.tensorboard.patch(save=False)`

This seems to be a similar problem to https://github.com/wandb/client/issues/2772 except in our case this only happens at windows.
