### PR TITLE
Hotfix: Log Trueskill again

### DIFF
--- a/experiments/new_league.py
+++ b/experiments/new_league.py
@@ -318,7 +318,6 @@ if __name__ == "__main__":
     all_ai_names = set(existing_ai_names + args.evals)
     if not args.update_db:
         shutil.copyfile("league.db", "league.db.backup")
-        shutil.copyfile("league.csv", "league.csv.backup")
 
     for ai_name in all_ai_names:  
         ai = AI.get_or_none(name=ai_name)
@@ -451,9 +450,7 @@ if __name__ == "__main__":
     get_leaderboard().to_csv("league.csv", index=False)
     if not args.update_db:
         os.remove("league.db")
-        os.remove("league.csv")
         shutil.move("league.db.backup", "league.db")
-        shutil.move("league.csv.backup", "league.csv")
 
         # if args.prod_mode:
         #     import wandb

--- a/experiments/ppo_gridnet.py
+++ b/experiments/ppo_gridnet.py
@@ -479,7 +479,6 @@ if __name__ == "__main__":
                 league = pd.read_csv("league.csv", index_col="name")
                 if len(eval_queue) > 0:
                     model_path = eval_queue[0]
-                    print("model_path in league.index", model_path, league.index, model_path in league.index)
                     if model_path in league.index:
                         model_global_step = int(model_path.split("/")[-1][:-3])
                         print(f"Model global step: {model_global_step}")

--- a/experiments/ppo_gridnet.py
+++ b/experiments/ppo_gridnet.py
@@ -337,9 +337,7 @@ if __name__ == "__main__":
         print(param_tensor, "\t", agent.state_dict()[param_tensor].size())
     total_params = sum([param.nelement() for param in agent.parameters()])
     print("Model's total parameters:", total_params)
-    if args.prod_mode:
-        all_league_df = pd.read_csv("league.csv")
-        eval_queue = []
+    all_league_df = None
 
     for update in range(starting_update, args.num_updates + 1):
         # Annealing the rate if instructed to do so.
@@ -480,6 +478,7 @@ if __name__ == "__main__":
                 league = pd.read_csv("league.csv", index_col="name")
                 if len(eval_queue) > 0:
                     model_path = eval_queue[0]
+                    print("model_path in league.index", model_path, league.index, model_path in league.index)
                     if model_path in league.index:
                         model_global_step = int(model_path.split("/")[-1][:-3])
                         print(f"Model global step: {model_global_step}")
@@ -487,7 +486,10 @@ if __name__ == "__main__":
                         print("charts/trueskill", league.loc[model_path]["trueskill"], model_global_step)
                         writer.add_scalar("charts/trueskill", league.loc[model_path]["trueskill"], model_global_step)
 
-                        all_league_df = all_league_df.append({"name": league.loc[model_path].name, "mu": league.loc[model_path]["mu"], "sigma":league.loc[model_path]["sigma"], "trueskill": league.loc[model_path]["trueskill"]}, ignore_index=True)
+                        if all_league_df is None:
+                            all_league_df = league
+                        else:
+                            all_league_df = all_league_df.append({"name": league.loc[model_path].name, "mu": league.loc[model_path]["mu"], "sigma":league.loc[model_path]["sigma"], "trueskill": league.loc[model_path]["trueskill"]}, ignore_index=True)
                         wandb.log({"trueskill": wandb.Table(dataframe=all_league_df)})
 
         # TRY NOT TO MODIFY: record rewards for plotting purposes
@@ -502,5 +504,5 @@ if __name__ == "__main__":
         writer.add_scalar("charts/sps", int(global_step / (time.time() - start_time)), global_step)
         print("SPS:", int(global_step / (time.time() - start_time)))
 
-    # envs.close()
-    # writer.close()
+    envs.close()
+    writer.close()

--- a/experiments/ppo_gridnet.py
+++ b/experiments/ppo_gridnet.py
@@ -487,7 +487,7 @@ if __name__ == "__main__":
                         writer.add_scalar("charts/trueskill", league.loc[model_path]["trueskill"], model_global_step)
 
                         if all_league_df is None:
-                            all_league_df = league
+                            all_league_df = pd.read_csv("league.csv")
                         else:
                             all_league_df = all_league_df.append({"name": league.loc[model_path].name, "mu": league.loc[model_path]["mu"], "sigma":league.loc[model_path]["sigma"], "trueskill": league.loc[model_path]["trueskill"]}, ignore_index=True)
                         wandb.log({"trueskill": wandb.Table(dataframe=all_league_df)})

--- a/experiments/ppo_gridnet.py
+++ b/experiments/ppo_gridnet.py
@@ -337,6 +337,7 @@ if __name__ == "__main__":
         print(param_tensor, "\t", agent.state_dict()[param_tensor].size())
     total_params = sum([param.nelement() for param in agent.parameters()])
     print("Model's total parameters:", total_params)
+    eval_queue = []
     all_league_df = None
 
     for update in range(starting_update, args.num_updates + 1):


### PR DESCRIPTION
This PR relog Trueskill again. It turns out we do need to change `league.csv`'s contents overtime.

Proof of concept run is here:

https://wandb.ai/costa-huang/gym-microrts/runs/18zrymwq

![image](https://user-images.githubusercontent.com/5555347/141011911-2babd52d-0afe-4079-8435-a6ef6312f320.png)
