### PR TITLE
Prototype native encoded observation

### DIFF
--- a/gym_microrts/envs/vec_env.py
+++ b/gym_microrts/envs/vec_env.py
@@ -132,18 +132,17 @@ class MicroRTSGridModeVecEnv:
 
     def reset(self):
         responses = self.vec_client.reset([0]*self.num_envs)
-        obs = [self._encode_obs(np.array(ro)) for ro in responses.observation]
-        return np.array(obs)
+        return np.array(responses.observation)
 
-    def _encode_obs(self, obs):
-        obs = obs.reshape(len(obs), -1).clip(0, np.array([self.num_planes]).T-1)
-        obs_planes = np.zeros((self.height * self.width, self.num_planes_prefix_sum[-1]), dtype=np.int32)
-        obs_planes_idx = np.arange(len(obs_planes))
-        obs_planes[obs_planes_idx,obs[0]] = 1
+    # def _encode_obs(self, obs):
+    #     obs = obs.reshape(len(obs), -1).clip(0, np.array([self.num_planes]).T-1)
+    #     obs_planes = np.zeros((self.height * self.width, self.num_planes_prefix_sum[-1]), dtype=np.int32)
+    #     obs_planes_idx = np.arange(len(obs_planes))
+    #     obs_planes[obs_planes_idx,obs[0]] = 1
 
-        for i in range(1, self.num_planes_len):
-            obs_planes[obs_planes_idx,obs[i]+self.num_planes_prefix_sum[i]] = 1
-        return obs_planes.reshape(self.height, self.width, -1)
+    #     for i in range(1, self.num_planes_len):
+    #         obs_planes[obs_planes_idx,obs[i]+self.num_planes_prefix_sum[i]] = 1
+    #     return obs_planes.reshape(self.height, self.width, -1)
 
     def step_async(self, actions):
         actions = actions.reshape((self.num_envs, self.width*self.height, -1))
@@ -163,7 +162,7 @@ class MicroRTSGridModeVecEnv:
     def step_wait(self):
         responses = self.vec_client.gameStep(self.actions, [0]*self.num_envs)
         reward, done = np.array(responses.reward), np.array(responses.done)
-        obs = [self._encode_obs(np.array(ro)) for ro in responses.observation]
+        obs = np.array(responses.observation)
         infos = [{"raw_rewards": item} for item in reward]
         return np.array(obs), reward @ self.reward_weight, done[:,0], infos
 


### PR DESCRIPTION
Old:
![image](https://user-images.githubusercontent.com/5555347/148618131-d35df10d-5e98-463c-bfec-1566d6d7545f.png)

New:
![image](https://user-images.githubusercontent.com/5555347/148617808-66c10df2-fa09-40e0-b2b2-d03df9e5fe48.png)

Turns of the new native encoded observation is slower... This likely means the JAVA shared array transfer is still more expensive than expected.

No longer exploring this line of optimziation.