### PR TITLE
Log discounted returns

### DIFF
--- a/experiments/ppo_gridnet.py
+++ b/experiments/ppo_gridnet.py
@@ -118,7 +118,10 @@ class MicroRTSStatsRecorder(VecEnvWrapper):
         newinfos = list(infos[:])
         for i in range(len(dones)):
             self.raw_rewards[i] += [infos[i]["raw_rewards"]]
-            self.raw_discount_rewards[i] += [(self.gamma ** self.ts[i]) * np.concatenate((infos[i]["raw_rewards"], infos[i]["raw_rewards"].sum()), axis=None)]
+            self.raw_discount_rewards[i] += [
+                (self.gamma ** self.ts[i])
+                * np.concatenate((infos[i]["raw_rewards"], infos[i]["raw_rewards"].sum()), axis=None)
+            ]
             self.ts[i] += 1
             if dones[i]:
                 info = infos[i].copy()


### PR DESCRIPTION
This PR also logs discounted returns. This metric is useful because the agent actually optimizes for chunks of discounted returns (chunks defined by `num_envs * num_steps`). I also logged the episodic length as well and change the metrics name from `episode_reward` to `episodic_return` to more accurately reflect the metric.