### PR TITLE
Training evaluation improvement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ experiments/mask/*
 benchmark/scripts/*
 videos
 dataset.pickle
+runs
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/experiments/league.py
+++ b/experiments/league.py
@@ -6,10 +6,10 @@ import itertools
 import os
 import random
 import shutil
-import time
+import uuid
 from distutils.util import strtobool
 from enum import Enum
-import uuid
+
 import numpy as np
 import pandas as pd
 import torch

--- a/experiments/league.py
+++ b/experiments/league.py
@@ -9,7 +9,7 @@ import shutil
 import time
 from distutils.util import strtobool
 from enum import Enum
-
+import uuid
 import numpy as np
 import pandas as pd
 import torch
@@ -74,7 +74,7 @@ csvpath = f"gym-microrts-static-files/{dbname}.csv"
 if not args.update_db:
     if not os.path.exists(f"gym-microrts-static-files/tmp"):
         os.makedirs(f"gym-microrts-static-files/tmp")
-    tmp_dbpath = f"gym-microrts-static-files/tmp/{int(time.time())}.db"
+    tmp_dbpath = f"gym-microrts-static-files/tmp/{str(uuid.uuid4())}.db"
     shutil.copyfile(dbpath, tmp_dbpath)
     dbpath = tmp_dbpath
 db = SqliteDatabase(dbpath)

--- a/experiments/ppo_gridnet.py
+++ b/experiments/ppo_gridnet.py
@@ -493,7 +493,7 @@ if __name__ == "__main__":
 
         while len(eval_queue) > 0:
             # always start the max-eval-workers processes
-            for idx in range(len(eval_queue[:args.max_eval_workers])):
+            for idx in range(len(eval_queue[: args.max_eval_workers])):
                 if type(eval_queue[idx][0]) == list:
                     eval_queue[idx][0] = subprocess.Popen(eval_queue[idx][0])
                     print(f"Evaluating {eval_queue[idx][1]}")

--- a/experiments/ppo_gridnet.py
+++ b/experiments/ppo_gridnet.py
@@ -5,6 +5,7 @@ import os
 import random
 import subprocess
 import time
+from concurrent.futures import ThreadPoolExecutor
 from distutils.util import strtobool
 
 import numpy as np
@@ -89,7 +90,7 @@ def parse_args():
     parser.add_argument('--num-models', type=int, default=200,
         help='the number of models saved')
     parser.add_argument('--max-eval-workers', type=int, default=2,
-        help='the maximum number of eval workers')
+        help='the maximum number of eval workers (skips evaluation when set to 0)')
 
     args = parser.parse_args()
     if not args.seed:
@@ -236,6 +237,66 @@ class Agent(nn.Module):
         return self.critic(self.encoder(x))
 
 
+def run_evaluation(model_path: str, output_path: str):
+    args = [
+        "python",
+        "league.py",
+        "--evals",
+        model_path,
+        "--update-db",
+        "false",
+        "--cuda",
+        "false",
+        "--output-path",
+        output_path,
+    ]
+    fd = subprocess.Popen(args)
+    print(f"Evaluating {model_path}")
+    return_code = fd.wait()
+    assert return_code == 0
+    return (model_path, output_path)
+
+
+class TrueskillWriter:
+    def __init__(self, prod_mode, writer, league_path: str, league_step_path: str):
+        self.prod_mode = prod_mode
+        self.writer = writer
+        self.trueskill_df = pd.read_csv(league_path)
+        self.trueskill_step_df = pd.read_csv(league_step_path)
+        self.trueskill_step_df["type"] = self.trueskill_step_df["name"]
+        self.trueskill_step_df["step"] = 0
+        # xxx(okachaiev): not sure we need this copy
+        self.preset_trueskill_step_df = self.trueskill_step_df.copy()
+
+    def on_evaluation_done(self, future):
+        if future.cancelled():
+            return
+        model_path, output_path = future.result()
+        league = pd.read_csv(output_path, index_col="name")
+        assert model_path in league.index
+        model_global_step = int(model_path.split("/")[-1][:-3])
+        self.writer.add_scalar("charts/trueskill", league.loc[model_path]["trueskill"], model_global_step)
+        print(f"global_step={model_global_step}, trueskill={league.loc[model_path]['trueskill']}")
+
+        # table visualization logic
+        if self.prod_mode:
+            trueskill_data = {
+                "name": league.loc[model_path].name,
+                "mu": league.loc[model_path]["mu"],
+                "sigma": league.loc[model_path]["sigma"],
+                "trueskill": league.loc[model_path]["trueskill"],
+            }
+            self.trueskill_df = self.trueskill_df.append(trueskill_data, ignore_index=True)
+            wandb.log({"trueskill": wandb.Table(dataframe=self.trueskill_df)})
+            trueskill_data["type"] = "training"
+            trueskill_data["step"] = model_global_step
+            self.trueskill_step_df = self.trueskill_step_df.append(trueskill_data, ignore_index=True)
+            preset_trueskill_step_df_clone = self.preset_trueskill_step_df.copy()
+            preset_trueskill_step_df_clone["step"] = model_global_step
+            self.trueskill_step_df = self.trueskill_step_df.append(preset_trueskill_step_df_clone, ignore_index=True)
+            wandb.log({"trueskill_step": wandb.Table(dataframe=self.trueskill_step_df)})
+
+
 if __name__ == "__main__":
     args = parse_args()
 
@@ -287,6 +348,10 @@ if __name__ == "__main__":
         )
     assert isinstance(envs.action_space, MultiDiscrete), "only MultiDiscrete action space is supported"
 
+    eval_executor = None
+    if args.max_eval_workers > 0:
+        eval_executor = ThreadPoolExecutor(max_workers=args.max_eval_workers, thread_name_prefix="league-eval-")
+
     agent = Agent(envs).to(device)
     optimizer = optim.Adam(agent.parameters(), lr=args.learning_rate, eps=1e-5)
     if args.anneal_lr:
@@ -334,12 +399,9 @@ if __name__ == "__main__":
     print("Model's total parameters:", total_params)
 
     ## EVALUATION LOGIC:
-    eval_queue = []
-    trueskill_df = pd.read_csv("gym-microrts-static-files/league.csv")
-    trueskill_step_df = pd.read_csv("gym-microrts-static-files/league.csv")
-    trueskill_step_df["type"] = trueskill_step_df["name"]
-    trueskill_step_df["step"] = 0
-    preset_trueskill_step_df = trueskill_step_df.copy()
+    trueskill_writer = TrueskillWriter(
+        args.prod_mode, writer, "gym-microrts-static-files/league.csv", "gym-microrts-static-files/league.csv"
+    )
 
     for update in range(starting_update, args.num_updates + 1):
         # Annealing the rate if instructed to do so.
@@ -471,64 +533,12 @@ if __name__ == "__main__":
             torch.save(agent.state_dict(), f"models/{experiment_name}/{global_step}.pt")
             if args.prod_mode:
                 wandb.save(f"models/{experiment_name}/agent.pt", base_path=f"models/{experiment_name}", policy="now")
-            eval_queue += [
-                [
-                    [
-                        "python",
-                        "league.py",
-                        "--evals",
-                        f"models/{experiment_name}/{global_step}.pt",
-                        "--update-db",
-                        "false",
-                        "--cuda",
-                        "false",
-                        "--output-path",
-                        f"runs/{experiment_name}/{global_step}.csv",
-                    ],
-                    f"models/{experiment_name}/{global_step}.pt",
-                    f"runs/{experiment_name}/{global_step}.csv",
-                ]
-            ]
-            print(f"Queued models/{experiment_name}/{global_step}.pt")
-
-        while len(eval_queue) > 0:
-            # always start the max-eval-workers processes
-            for idx in range(len(eval_queue[: args.max_eval_workers])):
-                if type(eval_queue[idx][0]) == list:
-                    eval_queue[idx][0] = subprocess.Popen(eval_queue[idx][0])
-                    print(f"Evaluating {eval_queue[idx][1]}")
-
-            if eval_queue[0][0].poll() is not None:
-                # read and clean up
-                league = pd.read_csv(eval_queue[0][2], index_col="name")
-                model_path = eval_queue[0][1]
-                eval_queue = eval_queue[1:]
-                assert model_path in league.index
-                model_global_step = int(model_path.split("/")[-1][:-3])
-                writer.add_scalar("charts/trueskill", league.loc[model_path]["trueskill"], model_global_step)
-                print(f"global_step={model_global_step}, trueskill={league.loc[model_path]['trueskill']}")
-
-                # table visualization logic
-                if args.prod_mode:
-                    trueskill_data = {
-                        "name": league.loc[model_path].name,
-                        "mu": league.loc[model_path]["mu"],
-                        "sigma": league.loc[model_path]["sigma"],
-                        "trueskill": league.loc[model_path]["trueskill"],
-                    }
-                    trueskill_df = trueskill_df.append(trueskill_data, ignore_index=True)
-                    wandb.log({"trueskill": wandb.Table(dataframe=trueskill_df)})
-                    trueskill_data["type"] = "training"
-                    trueskill_data["step"] = model_global_step
-                    trueskill_step_df = trueskill_step_df.append(trueskill_data, ignore_index=True)
-                    preset_trueskill_step_df_clone = preset_trueskill_step_df.copy()
-                    preset_trueskill_step_df_clone["step"] = model_global_step
-                    trueskill_step_df = trueskill_step_df.append(preset_trueskill_step_df_clone, ignore_index=True)
-                    wandb.log({"trueskill_step": wandb.Table(dataframe=trueskill_step_df)})
-
-            # if the training is not done, don't wait all eval processes to finish
-            if not update == args.num_updates:
-                break
+            if eval_executor is not None:
+                future = eval_executor.submit(
+                    run_evaluation, f"models/{experiment_name}/{global_step}.pt", f"runs/{experiment_name}/{global_step}.csv"
+                )
+                print(f"Queued models/{experiment_name}/{global_step}.pt")
+                future.add_done_callback(trueskill_writer.on_evaluation_done)
 
         # TRY NOT TO MODIFY: record rewards for plotting purposes
         writer.add_scalar("charts/learning_rate", optimizer.param_groups[0]["lr"], global_step)
@@ -542,5 +552,8 @@ if __name__ == "__main__":
         writer.add_scalar("charts/sps", int(global_step / (time.time() - start_time)), global_step)
         print("SPS:", int(global_step / (time.time() - start_time)))
 
+    if eval_executor is not None:
+        # shutdown pool of threads but make sure we finished scheduled evaluations
+        eval_executor.shutdown(wait=True, cancel_futures=False)
     envs.close()
     writer.close()

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -5,7 +5,7 @@ def test_ppo_gridnet():
 
     try:
         subprocess.run(
-            "cd experiments; python ppo_gridnet.py --num-bot-envs 0 --num-selfplay-envs 2 --num-steps 16 --total-timesteps 32 --cuda False",
+            "cd experiments; python ppo_gridnet.py --num-bot-envs 0 --num-selfplay-envs 2 --num-steps 16 --total-timesteps 32 --cuda False --max-eval-workers 0",
             shell=True,
             check=True,
         )


### PR DESCRIPTION
This PR does the following:
1. Wait all the `league.py`'s results finish before terminating the training process.
2. Support a maximum number of subprocess calls to do evaluations through the `--max-eval-workers 2`. This will help avoid overwhelming the host's CPU resources.

As an example, if you run `python ppo_gridnet.py --total-timesteps 30000`, based on the default `--num-models 200`, we will produce 4 models instead (`6144.pt, 12288.pt, 18432.pt, 24576.pt`). Then we will see the following output. Notice with the default `--max-eval-workers 2`, the highlighted message with `->` shows only two models `6144.pt, 12288.pt` are being evaluated with subprocess calls, while the other models are queued. Also the script blocks until all evaluations are finished.

```
Model's total parameters: 838191
-> Queued models/MicroRTSGridModeVecEnv__ppo_gridnet__1__1643412181/6144.pt
-> Evaluating models/MicroRTSGridModeVecEnv__ppo_gridnet__1__1643412181/6144.pt
SPS: 779
match_qualities[:3] [[<AI: 🤖 guidedRojoA3N with N(26.228, 0.979)>, 0.5706042609450162], [<AI: 🤖 rojo with N(26.345, 1.056)>, 0.569372689002722], [<AI: 🤖 naiveMCTSAI with N(26.798, 1.042)>, 0.5656072235262297]]
the match up is (🤖 models/MicroRTSGridModeVecEnv__ppo_gridnet__1__1643412181/6144.pt with N(25.0, 8.333), 🤖 rojo with N(26.345, 1.056)), quality is 0.5694
-> Queued models/MicroRTSGridModeVecEnv__ppo_gridnet__1__1643412181/12288.pt
-> Evaluating models/MicroRTSGridModeVecEnv__ppo_gridnet__1__1643412181/12288.pt
SPS: 754
match_qualities[:3] [[<AI: 🤖 guidedRojoA3N with N(26.228, 0.979)>, 0.5706042609450162], [<AI: 🤖 rojo with N(26.345, 1.056)>, 0.569372689002722], [<AI: 🤖 naiveMCTSAI with N(26.798, 1.042)>, 0.5656072235262297]]
the match up is (🤖 models/MicroRTSGridModeVecEnv__ppo_gridnet__1__1643412181/12288.pt with N(25.0, 8.333), 🤖 rojo with N(26.345, 1.056)), quality is 0.5694
rojo wins models/MicroRTSGridModeVecEnv__ppo_gridnet__1__1643412181/6144.pt
-> Queued models/MicroRTSGridModeVecEnv__ppo_gridnet__1__1643412181/18432.pt
SPS: 681
-> Queued models/MicroRTSGridModeVecEnv__ppo_gridnet__1__1643412181/24576.pt
rojo wins models/MicroRTSGridModeVecEnv__ppo_gridnet__1__1643412181/12288.pt
rojo wins models/MicroRTSGridModeVecEnv__ppo_gridnet__1__1643412181/6144.pt
match_qualities[:3] [[<AI: 🤖 randomBiasedAI with N(14.676, 1.318)>, 0.6678117557349951], [<AI: 🤖 randomAI with N(12.602, 1.428)>, 0.5858232592199697], [<AI: 🤖 guidedRojoA3N with N(26.228, 0.979)
```
