### PR TITLE
Introduce smaller and more efficient NN architecture

### DIFF
--- a/experiments/league.py
+++ b/experiments/league.py
@@ -24,12 +24,10 @@ from peewee import (
     SqliteDatabase,
     fn,
 )
-from ppo_gridnet import Agent, MicroRTSStatsRecorder
 from stable_baselines3.common.vec_env import VecMonitor
 from trueskill import Rating, quality_1vs1, rate_1vs1
 
 from gym_microrts import microrts_ai  # fmt: off
-from gym_microrts.envs.vec_env import MicroRTSBotVecEnv, MicroRTSGridModeVecEnv
 
 
 def parse_args():
@@ -58,6 +56,8 @@ def parse_args():
         help='the highest sigma of the trueskill evaluation')
     parser.add_argument('--output-path', type=str, default=f"league.temp.csv",
         help='the output path of the leaderboard csv')
+    parser.add_argument('--model-type', type=str, default=f"ppo_gridnet_large", choices=["ppo_gridnet_large", "ppo_gridnet"],
+        help='the output path of the leaderboard csv')
     # ["randomBiasedAI","workerRushAI","lightRushAI","coacAI"]
     # default=["randomBiasedAI","workerRushAI","lightRushAI","coacAI","randomAI","passiveAI","naiveMCTSAI","mixedBot","rojo","izanagi","tiamat","droplet","guidedRojoA3N"]
     args = parser.parse_args()
@@ -78,6 +78,18 @@ if not args.update_db:
     shutil.copyfile(dbpath, tmp_dbpath)
     dbpath = tmp_dbpath
 db = SqliteDatabase(dbpath)
+
+if args.model_type == "ppo_gridnet_large":
+    from ppo_gridnet_large import Agent, MicroRTSStatsRecorder
+
+    from gym_microrts.envs.vec_env import MicroRTSBotVecEnv, MicroRTSGridModeVecEnv
+else:
+    from ppo_gridnet import Agent, MicroRTSStatsRecorder
+
+    from gym_microrts.envs.vec_env import MicroRTSBotVecEnv
+    from gym_microrts.envs.vec_env import (
+        MicroRTSGridModeSharedMemVecEnv as MicroRTSGridModeVecEnv,
+    )
 
 
 class BaseModel(Model):

--- a/experiments/league.py
+++ b/experiments/league.py
@@ -29,6 +29,8 @@ from trueskill import Rating, quality_1vs1, rate_1vs1
 
 from gym_microrts import microrts_ai  # fmt: off
 
+torch.set_num_threads(1)
+
 
 def parse_args():
     # fmt: off

--- a/experiments/ppo_gridnet.py
+++ b/experiments/ppo_gridnet.py
@@ -35,7 +35,7 @@ def parse_args():
         help='the learning rate of the optimizer')
     parser.add_argument('--seed', type=int, default=1,
         help='seed of the experiment')
-    parser.add_argument('--total-timesteps', type=int, default=100000000,
+    parser.add_argument('--total-timesteps', type=int, default=50000000,
         help='total timesteps of the experiments')
     parser.add_argument('--torch-deterministic', type=lambda x: bool(strtobool(x)), default=True, nargs='?', const=True,
         help='if toggled, `torch.backends.cudnn.deterministic=False`')

--- a/experiments/ppo_gridnet.py
+++ b/experiments/ppo_gridnet.py
@@ -89,9 +89,9 @@ def parse_args():
         help="Toggle learning rate annealing for policy and value networks")
     parser.add_argument('--clip-vloss', type=lambda x: bool(strtobool(x)), default=True, nargs='?', const=True,
         help='Toggles whether or not to use a clipped loss for the value function, as per the paper.')
-    parser.add_argument('--num-models', type=int, default=200,
+    parser.add_argument('--num-models', type=int, default=100,
         help='the number of models saved')
-    parser.add_argument('--max-eval-workers', type=int, default=2,
+    parser.add_argument('--max-eval-workers', type=int, default=4,
         help='the maximum number of eval workers (skips evaluation when set to 0)')
 
     args = parser.parse_args()

--- a/experiments/ppo_gridnet_eval.py
+++ b/experiments/ppo_gridnet_eval.py
@@ -10,12 +10,10 @@ import numpy as np
 import torch
 import torch.optim as optim
 from gym.spaces import MultiDiscrete
-from ppo_gridnet import Agent, MicroRTSStatsRecorder
 from stable_baselines3.common.vec_env import VecMonitor, VecVideoRecorder
 from torch.utils.tensorboard import SummaryWriter
 
 from gym_microrts import microrts_ai  # noqa
-from gym_microrts.envs.vec_env import MicroRTSGridModeVecEnv
 
 
 def parse_args():
@@ -55,7 +53,8 @@ def parse_args():
         help="the path to the agent's model")
     parser.add_argument('--ai', type=str, default="",
         help='the opponent AI to evaluate against')
-
+    parser.add_argument('--model-type', type=str, default=f"ppo_gridnet_large", choices=["ppo_gridnet_large", "ppo_gridnet"],
+        help='the output path of the leaderboard csv')
     args = parser.parse_args()
     if not args.seed:
         args.seed = int(time.time())
@@ -72,6 +71,17 @@ def parse_args():
 
 if __name__ == "__main__":
     args = parse_args()
+
+    if args.model_type == "ppo_gridnet_large":
+        from ppo_gridnet_large import Agent, MicroRTSStatsRecorder
+
+        from gym_microrts.envs.vec_env import MicroRTSGridModeVecEnv
+    else:
+        from ppo_gridnet import Agent, MicroRTSStatsRecorder
+
+        from gym_microrts.envs.vec_env import (
+            MicroRTSGridModeSharedMemVecEnv as MicroRTSGridModeVecEnv,
+        )
 
     # TRY NOT TO MODIFY: setup the environment
     experiment_name = f"{args.gym_id}__{args.exp_name}__{args.seed}__{int(time.time())}"

--- a/experiments/ppo_gridnet_large.py
+++ b/experiments/ppo_gridnet_large.py
@@ -33,7 +33,7 @@ def parse_args():
         help='the learning rate of the optimizer')
     parser.add_argument('--seed', type=int, default=1,
         help='seed of the experiment')
-    parser.add_argument('--total-timesteps', type=int, default=100000000,
+    parser.add_argument('--total-timesteps', type=int, default=300000000,
         help='total timesteps of the experiments')
     parser.add_argument('--torch-deterministic', type=lambda x: bool(strtobool(x)), default=True, nargs='?', const=True,
         help='if toggled, `torch.backends.cudnn.deterministic=False`')


### PR DESCRIPTION
This PR introduces a smaller and more efficient NN architecture. Namely, replace the existing

```python
    def __init__(self, envs, mapsize=16 * 16):
        super(Agent, self).__init__()
        self.mapsize = mapsize
        h, w, c = envs.observation_space.shape
        self.encoder = nn.Sequential(
            Transpose((0, 3, 1, 2)),
            layer_init(nn.Conv2d(c, 32, kernel_size=3, padding=1)),
            nn.MaxPool2d(3, stride=2, padding=1),
            nn.ReLU(),
            layer_init(nn.Conv2d(32, 64, kernel_size=3, padding=1)),
            nn.MaxPool2d(3, stride=2, padding=1),
            nn.ReLU(),
            layer_init(nn.Conv2d(64, 128, kernel_size=3, padding=1)),
            nn.MaxPool2d(3, stride=2, padding=1),
            nn.ReLU(),
            layer_init(nn.Conv2d(128, 256, kernel_size=3, padding=1)),
            nn.MaxPool2d(3, stride=2, padding=1),
        )

        self.actor = nn.Sequential(
            layer_init(nn.ConvTranspose2d(256, 128, 3, stride=2, padding=1, output_padding=1)),
            nn.ReLU(),
            layer_init(nn.ConvTranspose2d(128, 64, 3, stride=2, padding=1, output_padding=1)),
            nn.ReLU(),
            layer_init(nn.ConvTranspose2d(64, 32, 3, stride=2, padding=1, output_padding=1)),
            nn.ReLU(),
            layer_init(nn.ConvTranspose2d(32, 78, 3, stride=2, padding=1, output_padding=1)),
            Transpose((0, 2, 3, 1)),
        )
        self.critic = nn.Sequential(
            nn.Flatten(),
            layer_init(nn.Linear(256, 128)),
            nn.ReLU(),
            layer_init(nn.Linear(128, 1), std=1),
        )
        self.register_buffer("mask_value", torch.tensor(-1e8))
```

with the following

```python
    def __init__(self, envs, mapsize=16 * 16):
        super(Agent, self).__init__()
        self.mapsize = mapsize
        h, w, c = envs.observation_space.shape
        self.encoder = nn.Sequential(
            Transpose((0, 3, 1, 2)),
            layer_init(nn.Conv2d(c, 32, kernel_size=3, padding=1)),
            nn.MaxPool2d(3, stride=2, padding=1),
            nn.ReLU(),
            layer_init(nn.Conv2d(32, 64, kernel_size=3, padding=1)),
            nn.MaxPool2d(3, stride=2, padding=1),
            nn.ReLU(),
        )

        self.actor = nn.Sequential(
            layer_init(nn.ConvTranspose2d(64, 32, 3, stride=2, padding=1, output_padding=1)),
            nn.ReLU(),
            layer_init(nn.ConvTranspose2d(32, 78, 3, stride=2, padding=1, output_padding=1)),
            Transpose((0, 2, 3, 1)),
        )
        self.critic = nn.Sequential(
            nn.Flatten(),
            layer_init(nn.Linear(64 * 4 * 4, 128)),
            nn.ReLU(),
            layer_init(nn.Linear(128, 1), std=1),
        )
        self.register_buffer("mask_value", torch.tensor(-1e8))
```

[Preliminary experiment](https://wandb.ai/gym-microrts/gym-microrts/runs/13tizcke?workspace=user-costa-huang) shows it can also produce a sota model but only taking about 16 hours (50M steps) and 36 hours in total to wait for all evaluations to finish.

![image](https://user-images.githubusercontent.com/5555347/151864229-5c47875b-d210-4d2c-a91e-57aa68a37f31.png)

@cpuheater

In contrast, the previous [SOTA model](https://wandb.ai/costa-huang/gym-microrts/runs/2v658xqx/overview?workspace=user-costa-huang) (using the larger model) gains a bit higher Trueskill which tasks in about 109 hours

![image](https://user-images.githubusercontent.com/5555347/151865018-217ae7c6-a8d5-417e-b8d5-2e5c1bb10211.png)

Given this evidence, this PR makes the code base use the default smaller model to save compute.
