### PR TITLE
Better error and warning

### DIFF
--- a/gym_microrts/envs/vec_env.py
+++ b/gym_microrts/envs/vec_env.py
@@ -41,6 +41,8 @@ MICRORTS_MAC_OS_RENDER_MESSAGE = """
 gym-microrts render is not available on MacOS. See https://github.com/jpype-project/jpype/issues/906
 
 It is however possible to record the videos via `env.render(mode='rgb_array')`. 
+See https://github.com/vwxyzjn/gym-microrts/blob/b46c0815efd60ae959b70c14659efb95ef16ffb0/hello_world_record_video.py
+as an example.
 """
 
 
@@ -267,7 +269,7 @@ class MicroRTSGridModeVecEnv:
     def render(self, mode="human"):
         # give warning on macos because the render is not available
         if sys.platform == "darwin":
-            warnings.warn("", stacklevel=2)
+            warnings.warn(MICRORTS_MAC_OS_RENDER_MESSAGE)
 
         if mode == "human":
             self.render_client.render(False)

--- a/gym_microrts/envs/vec_env.py
+++ b/gym_microrts/envs/vec_env.py
@@ -267,12 +267,11 @@ class MicroRTSGridModeVecEnv:
             return None
 
     def render(self, mode="human"):
-        # give warning on macos because the render is not available
-        if sys.platform == "darwin":
-            warnings.warn(MICRORTS_MAC_OS_RENDER_MESSAGE)
-
         if mode == "human":
             self.render_client.render(False)
+            # give warning on macos because the render is not available
+            if sys.platform == "darwin":
+                warnings.warn(MICRORTS_MAC_OS_RENDER_MESSAGE)
         elif mode == "rgb_array":
             bytes_array = np.array(self.render_client.render(True))
             image = Image.frombytes("RGB", (640, 640), bytes_array)

--- a/hello_world_record_video.py
+++ b/hello_world_record_video.py
@@ -1,0 +1,63 @@
+import numpy as np
+
+from gym_microrts import microrts_ai
+from gym_microrts.envs.vec_env import MicroRTSGridModeVecEnv
+
+# if you want to record videos, install stable-baselines3 and use its `VecVideoRecorder`
+from stable_baselines3.common.vec_env import VecVideoRecorder
+
+
+envs = MicroRTSGridModeVecEnv(
+    num_selfplay_envs=2,
+    num_bot_envs=1,
+    max_steps=2000,
+    render_theme=2,
+    ai2s=[microrts_ai.coacAI for _ in range(1)],
+    map_paths=["maps/16x16/basesWorkers16x16.xml"],
+    reward_weight=np.array([10.0, 1.0, 1.0, 0.2, 1.0, 4.0]),
+)
+envs = VecVideoRecorder(envs, 'videos', record_video_trigger=lambda x: x % 4000 == 0, video_length=2000)
+
+
+def softmax(x, axis=None):
+    x = x - x.max(axis=axis, keepdims=True)
+    y = np.exp(x)
+    return y / y.sum(axis=axis, keepdims=True)
+
+
+def sample(logits):
+    # https://stackoverflow.com/a/40475357/6611317
+    p = softmax(logits, axis=1)
+    c = p.cumsum(axis=1)
+    u = np.random.rand(len(c), 1)
+    choices = (u < c).argmax(axis=1)
+    return choices.reshape(-1, 1)
+
+
+envs.action_space.seed(0)
+envs.reset()
+nvec = envs.action_space.nvec
+
+for i in range(10000):
+    envs.render()
+    action_mask = envs.get_action_mask()
+    action_mask = action_mask.reshape(-1, action_mask.shape[-1])
+    action_mask[action_mask == 0] = -9e8
+    # sample valid actions
+    action = np.concatenate(
+        (
+            sample(action_mask[:, 0:6]),  # action type
+            sample(action_mask[:, 6:10]),  # move parameter
+            sample(action_mask[:, 10:14]),  # harvest parameter
+            sample(action_mask[:, 14:18]),  # return parameter
+            sample(action_mask[:, 18:22]),  # produce_direction parameter
+            sample(action_mask[:, 22:29]),  # produce_unit_type parameter
+            # attack_target parameter
+            sample(action_mask[:, 29 : sum(envs.action_space.nvec[1:])]),
+        ),
+        axis=1,
+    )
+    # doing the following could result in invalid actions
+    # action = np.array([envs.action_space.sample()])
+    next_obs, reward, done, info = envs.step(action)
+envs.close()

--- a/hello_world_record_video.py
+++ b/hello_world_record_video.py
@@ -1,11 +1,10 @@
 import numpy as np
 
-from gym_microrts import microrts_ai
-from gym_microrts.envs.vec_env import MicroRTSGridModeVecEnv
-
 # if you want to record videos, install stable-baselines3 and use its `VecVideoRecorder`
 from stable_baselines3.common.vec_env import VecVideoRecorder
 
+from gym_microrts import microrts_ai
+from gym_microrts.envs.vec_env import MicroRTSGridModeVecEnv
 
 envs = MicroRTSGridModeVecEnv(
     num_selfplay_envs=2,
@@ -16,7 +15,7 @@ envs = MicroRTSGridModeVecEnv(
     map_paths=["maps/16x16/basesWorkers16x16.xml"],
     reward_weight=np.array([10.0, 1.0, 1.0, 0.2, 1.0, 4.0]),
 )
-envs = VecVideoRecorder(envs, 'videos', record_video_trigger=lambda x: x % 4000 == 0, video_length=2000)
+envs = VecVideoRecorder(envs, "videos", record_video_trigger=lambda x: x % 4000 == 0, video_length=2000)
 
 
 def softmax(x, axis=None):


### PR DESCRIPTION
This PR adds a better error message when `microrts.jar` is not built and a better warning message when trying to `render()` on macos.